### PR TITLE
fix(deps): add scheduler and react-reconciler as dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,12 +37,13 @@
     "husky": "^4.2.5",
     "lint-staged": "^10.2.11",
     "prettier": "^2.0.5",
-    "rimraf": "^3.0.2",
     "react": "^16.13.1",
     "react-reconciler": "^0.25.1",
+    "rimraf": "^3.0.2",
     "rollup": "^2.26.10",
     "rollup-plugin-size-snapshot": "^0.12.0",
-    "rollup-plugin-terser": "^7.0.2"
+    "rollup-plugin-terser": "^7.0.2",
+    "scheduler": "^0.20.2"
   },
   "peerDependencies": {
     "react": ">=16"

--- a/package.json
+++ b/package.json
@@ -38,11 +38,13 @@
     "lint-staged": "^10.2.11",
     "prettier": "^2.0.5",
     "react": "^16.13.1",
-    "react-reconciler": "^0.25.1",
     "rimraf": "^3.0.2",
     "rollup": "^2.26.10",
     "rollup-plugin-size-snapshot": "^0.12.0",
-    "rollup-plugin-terser": "^7.0.2",
+    "rollup-plugin-terser": "^7.0.2"
+  },
+  "dependencies": {
+    "react-reconciler": "^0.25.1",
     "scheduler": "^0.20.2"
   },
   "peerDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -4037,6 +4037,14 @@ scheduler@^0.19.1:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
 
+scheduler@^0.20.2:
+  version "0.20.2"
+  resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
+  integrity sha512-2eWfGgAqqWFGqtdMmcL5zCMK1U8KlXv8SQFGglL3CEtd0aDVDWgeF/YoCmvln55m5zSk3J/20hTaSBeSObsQDQ==
+  dependencies:
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+
 schema-utils@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/schema-utils/-/schema-utils-1.0.0.tgz#0b79a93204d7b600d4b2850d1f66c2a34951c770"


### PR DESCRIPTION
Fixes #6 and #7.

`react-reconciler` requires `scheduler` to be installed alongside it. Users shouldn't be burdened with internal dependencies, so I thought we can include it here.