### PR TITLE
feat: return JSON tree from `render`

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { suspend } from 'suspend-react'
 import { vi, it, expect } from 'vitest'
-import { type NilElement, render, act, type HostContainer } from './index'
+import { render, act, type HostContainer } from './index'
 
 declare global {
   var IS_REACT_ACT_ENVIRONMENT: boolean
@@ -17,12 +17,18 @@ vi.mock('scheduler', () => require('scheduler/unstable_mock'))
 const logError = global.console.error.bind(global.console.error)
 global.console.error = (...args: any[]) => !args[0].startsWith('Warning') && logError(...args)
 
+interface ReactProps {
+  key?: React.Key
+  ref?: React.Ref<null>
+  children?: React.ReactNode
+}
+
 declare global {
   namespace JSX {
     interface IntrinsicElements {
-      element: NilElement
-      parent: NilElement<{ foo: boolean }>
-      child: NilElement<{ bar: boolean }>
+      element: ReactProps
+      parent: ReactProps & { foo: boolean }
+      child: ReactProps & { bar: boolean }
     }
   }
 }

--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react'
 import { suspend } from 'suspend-react'
 import { vi, it, expect } from 'vitest'
-import { type NilElement, render, act } from './index'
+import { type NilElement, render, act, type HostContainer } from './index'
 
 declare global {
   var IS_REACT_ACT_ENVIRONMENT: boolean
@@ -71,17 +71,17 @@ it('should handle text', async () => {
   await act(async () => render(<Test />))
 })
 
-it('should pass tree as JSON to refs', async () => {
-  const ref = React.createRef<any>()
+it('should pass tree as JSON from render', async () => {
+  let container!: HostContainer
   await act(async () => {
-    render(
-      <parent foo ref={ref}>
+    container = render(
+      <parent foo>
         <child bar>text</child>
       </parent>,
     )
   })
 
-  expect(ref.current).toStrictEqual({
+  expect(container.head).toStrictEqual({
     type: 'parent',
     props: { foo: true },
     children: [

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,12 +8,6 @@ export interface NilNode<P = {}> {
   children: NilNode[]
 }
 
-export type NilElement<P = {}> = {
-  key?: React.Key
-  ref?: React.Ref<NilNode<P>>
-  children?: React.ReactNode
-} & P
-
 export interface HostContainer {
   head: NilNode | null
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,15 +2,27 @@ import * as React from 'react'
 import Reconciler from 'react-reconciler'
 import { DefaultEventPriority, ConcurrentRoot } from 'react-reconciler/constants.js'
 
+export interface NilNode<P = {}> {
+  type: string
+  props: P
+  children: NilNode[]
+}
+
+export type NilElement<P = {}> = {
+  key?: React.Key
+  ref?: React.Ref<NilNode<P>>
+  children?: React.ReactNode
+} & P
+
 interface HostConfig {
-  type: never
-  props: never
+  type: string
+  props: Record<string, unknown>
   container: {}
-  instance: null
-  textInstance: null
-  suspenseInstance: null
+  instance: NilNode
+  textInstance: NilNode
+  suspenseInstance: NilNode
   hydratableInstance: never
-  publicInstance: null
+  publicInstance: NilNode
   hostContext: null
   updatePayload: null
   childSet: never
@@ -41,17 +53,17 @@ const reconciler = Reconciler<
   scheduleTimeout: setTimeout,
   cancelTimeout: clearTimeout,
   noTimeout: -1,
-  createInstance: () => null,
+  createInstance: (type, { ref, key, children, ...props }) => ({ type, props, children: [] }),
   hideInstance() {},
   unhideInstance() {},
-  createTextInstance: () => null,
+  createTextInstance: (value) => ({ type: 'text', props: { value }, children: [] }),
   hideTextInstance() {},
   unhideTextInstance() {},
-  appendInitialChild() {},
-  appendChild() {},
+  appendInitialChild: (parent, child) => parent.children.push(child),
+  appendChild: (parent, child) => parent.children.push(child),
   appendChildToContainer() {},
-  insertBefore() {},
-  removeChild() {},
+  insertBefore: (parent, child, beforeChild) => parent.children.splice(parent.children.indexOf(beforeChild), 0, child),
+  removeChild: (parent, child) => parent.children.splice(parent.children.indexOf(child), 1),
   removeChildFromContainer() {},
   getPublicInstance: (instance) => instance,
   getRootHostContext: () => null,
@@ -59,7 +71,8 @@ const reconciler = Reconciler<
   shouldSetTextContent: () => false,
   finalizeInitialChildren: () => false,
   prepareUpdate: () => null,
-  commitUpdate() {},
+  commitUpdate: (instance, _, __, ___, { ref, key, children, ...props }) => Object.assign(instance.props, props),
+  commitTextUpdate: (instance, _, value) => Object.assign(instance.props, { value }),
   prepareForCommit: () => null,
   resetAfterCommit() {},
   preparePortalMount() {},


### PR DESCRIPTION
Implements #5 by serializing react instance trees into `HeadContainer`, returned by `render`.

```tsx
// { head: { type: 'element', props: {}, children: [] } }
render(<element />)
```