### PR TITLE
fix(types): act should infer return type

### DIFF
--- a/src/index.test.tsx
+++ b/src/index.test.tsx
@@ -38,9 +38,10 @@ it('should go through lifecycle', async () => {
     React.useEffect(() => void lifecycle.push('useEffect'), [])
     return null
   }
-  await act(async () => render(<Test />))
+  const container: HostContainer = await act(async () => render(<Test />))
 
   expect(lifecycle).toStrictEqual(['render', 'useInsertionEffect', 'ref', 'useLayoutEffect', 'useEffect'])
+  expect(container.head).toBe(null)
 })
 
 it('should render no-op elements', async () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -115,7 +115,7 @@ export function render(element: React.ReactNode): HostContainer {
 }
 
 declare module 'react' {
-  const unstable_act: (cb: () => Promise<any>) => Promise<any>
+  const unstable_act: <T = any>(cb: () => Promise<T>) => Promise<T>
 }
 
 /**


### PR DESCRIPTION
Corrects the return type of `React.unstable_act` to properly infer a return type from the passed callback.