### PR TITLE
fix: narrow React range for 18 reconciler

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "react-reconciler": "^0.27.0"
   },
   "peerDependencies": {
-    "react": ">=18.0"
+    "react": "^18.0.0"
   },
   "scripts": {
     "build": "rimraf dist && vite build && tsc",


### PR DESCRIPTION
Narrows the peer dep range for React as v1 only implements a React 18 reconciler. React 19 will be supported in the next major v2.